### PR TITLE
feat: import and configure react-toastify and add new features to dancing pad and buzz wire game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,10 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
+        "react-toastify": "^10.0.5",
+        "recharts": "^2.12.7",
         "web-vitals": "^2.1.4",
-        "ws": "^8.17.1",
-        "recharts": "^2.12.7"
+        "ws": "^8.17.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -16755,6 +16756,18 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
+    "react-toastify": "^10.0.5",
+    "recharts": "^2.12.7",
     "web-vitals": "^2.1.4",
-    "ws": "^8.17.1",
-    "recharts": "^2.12.7"
+    "ws": "^8.17.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/Buzzwire.js
+++ b/src/components/Buzzwire.js
@@ -34,7 +34,7 @@ export default function Memory() {
           <div className="mem-title">Highest Score</div>
         </div>
         <div className="mem-text-wrapper-3">
-          <p className="mem-highscore">{highScore}</p>
+          <p className="mem-highscore">{Math.round(highScore/1000)}</p>
         </div>
       </div>
     </div>

--- a/src/components/Dancing.js
+++ b/src/components/Dancing.js
@@ -205,7 +205,12 @@ export default function Dancing({ dance, danceTime, onWebSocketClose }) {
           </div>
         </div>
       </div>
-      <ToastContainer />
+      <ToastContainer
+        style={{
+          width: "400px",
+          fontSize: "25px",
+        }}
+      />
     </div>
   );
 }

--- a/src/components/Dancing.js
+++ b/src/components/Dancing.js
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from "react";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import "../styles/Dancing.css";
 import { rdb } from "../firebase/firebaseConfig.js";
 import { ref, get, update } from "firebase/database";
@@ -101,6 +103,7 @@ export default function Dancing({ dance, danceTime, onWebSocketClose }) {
       console.log("Sent: " + nextInteger);
       setCurrentIndex((currentIndex + 1) % integers.length);
     } else {
+      toast.error("WebSocket is not connected or countdown is not active");
       console.log("WebSocket is not connected or countdown is not active");
     }
   };
@@ -202,6 +205,7 @@ export default function Dancing({ dance, danceTime, onWebSocketClose }) {
           </div>
         </div>
       </div>
+      <ToastContainer />
     </div>
   );
 }

--- a/src/components/DashPomodoro.js
+++ b/src/components/DashPomodoro.js
@@ -69,7 +69,12 @@ export default function DashPomodoro({ socket }) {
           </p>
         </div>
       </div>
-      <ToastContainer />
+      <ToastContainer
+        style={{
+          width: "400px",
+          fontSize: "25px",
+        }}
+      />
     </>
   );
 }

--- a/src/components/DashPomodoro.js
+++ b/src/components/DashPomodoro.js
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import "../styles/DashPomodoro.css";
 import Down from "../assets/images/down 1.png";
 import Up from "../assets/images/up 1.png";
@@ -22,6 +24,7 @@ export default function DashPomodoro({ socket }) {
       socket.send(currentSession.toString());
       console.log("Sent: " + currentSession);
     } else {
+      toast.error("WebSocket is not connected");
       console.log("WebSocket is not connected");
     }
   };
@@ -66,6 +69,7 @@ export default function DashPomodoro({ socket }) {
           </p>
         </div>
       </div>
+      <ToastContainer />
     </>
   );
 }

--- a/src/components/ProgressChartArea.js
+++ b/src/components/ProgressChartArea.js
@@ -21,7 +21,7 @@ export default function ProgressChartArea() {
         const snapshot = await getDocs(collectionRef);
         const data = snapshot.docs.map((doc) => ({
           ...doc.data(),
-          numDetections: parseInt(doc.data().numDetections, 10), // Ensure numDetections is a number
+          Succesful_Sessions: parseInt(doc.data().Succesful_Sessions, 10), // Ensure Succesful_Sessions is a number
         }));
         setSessions(data);
       } catch (err) {
@@ -37,9 +37,9 @@ export default function ProgressChartArea() {
       const aggregated = sessions.reduce((acc, session) => {
         const date = session.date;
         if (!acc[date]) {
-          acc[date] = { date, numDetections: 0 };
+          acc[date] = { date, Succesful_Sessions: 0 };
         }
-        acc[date].numDetections += session.numDetections;
+        acc[date].Succesful_Sessions += session.Succesful_Sessions;
         return acc;
       }, {});
 
@@ -60,7 +60,7 @@ export default function ProgressChartArea() {
         data={aggregatedSessions}
         width={1100}
         height={600}
-        margin={{right: 50}}
+        margin={{ right: 50 }}
       >
         <XAxis
           dataKey="date"
@@ -75,7 +75,7 @@ export default function ProgressChartArea() {
         <Legend wrapperStyle={{ fontSize: "26px" }} />
         <Area
           type="monotone"
-          dataKey="numDetections"
+          dataKey="Succesful_Sessions"
           stroke="#2563eb"
           fill="#304674"
         />

--- a/src/components/ProgressChartArea.js
+++ b/src/components/ProgressChartArea.js
@@ -78,6 +78,7 @@ export default function ProgressChartArea() {
           dataKey="Succesful_Sessions"
           stroke="#2563eb"
           fill="#304674"
+          dot={{ fill: "#000000", stroke: "#2563eb", strokeWidth: 2, r: 4 }}
         />
       </AreaChart>
     </>

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -66,6 +66,7 @@ export default function Dashboard() {
     RenderedComponent = (
       <Dancing
         dance={dance}
+        setDance={setDance}
         danceTime={danceTime}
         onWebSocketClose={handleDashClick}
       />


### PR DESCRIPTION
This pull request includes the following changes:

- Import and configure `react-toastify` for toast notifications.
- Add a countdown to track the time ESP32 sends and provide remaining time on the dancing pad.
- Add a prop call to the dancing pad to change dance status when time is over.
- Round buzz wire high score to the nearest integer.
- Add dots to identify values in various components.