### PR TITLE
chore: remove onclick events and related props from memory and buzzwire components

### DIFF
--- a/src/components/DashboardHome.js
+++ b/src/components/DashboardHome.js
@@ -9,8 +9,6 @@ export default function DashboardHome({
   onSettingsClick,
   onStatsClick,
   onDanceClick,
-  onMemoryClick,
-  onBuzzClick,
 }) {
   return (
     <>
@@ -44,17 +42,12 @@ export default function DashboardHome({
         <div className="text-wrapper-05">25 : 00</div>
         <div className="text-wrapper-06">Pomodoro Timer</div>
       </div>
-      <div
-        className="overlap-5 game-tiles"
-        role="button"
-        tabIndex={0}
-        onClick={onBuzzClick}
-      >
+      <div className="overlap-5 game-tiles">
         <div className="text-wrapper-07">Buzzwire Game</div>
         <img className="ram-memory" alt="Ram memory" src={Buzzwire} />
       </div>
       <div
-        className="overlap-6 game-tiles"
+        className="overlap-6 game-tiles dancing-game-tiles"
         role="button"
         tabIndex={0}
         onClick={onDanceClick}
@@ -62,12 +55,7 @@ export default function DashboardHome({
         <div className="text-wrapper-07">Dancing Game</div>
         <img className="grade" alt="Grade" src={Dancingpad} />
       </div>
-      <div
-        className="overlap-7 game-tiles"
-        role="button"
-        tabIndex={0}
-        onClick={onMemoryClick}
-      >
+      <div className="overlap-7 game-tiles">
         <div className="text-wrapper-07">Memory Game</div>
         <img className="element-f" alt="Element f" src={Memorygame} />
       </div>

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -7,8 +7,6 @@ import DashPomodoro from "../components/DashPomodoro.js";
 import DasboardStatus from "../components/DashboardStatus.js";
 import DashProgress from "../components/DashProgress.js";
 import Dancing from "../components/Dancing.js";
-import Memory from "../components/Memory.js";
-import Buzzwire from "../components/Buzzwire.js";
 
 export default function Dashboard() {
   const [currentComponent, setCurrentComponent] = useState("home");
@@ -37,16 +35,6 @@ export default function Dashboard() {
     setCurrentMenu("status");
   };
 
-  const handleMemoryClick = () => {
-    setCurrentComponent("memory");
-    setCurrentMenu("status");
-  };
-
-  const handleBuzzClick = () => {
-    setCurrentComponent("buzz");
-    setCurrentMenu("status");
-  };
-
   let RenderedComponent;
   if (currentComponent === "home") {
     RenderedComponent = (
@@ -54,8 +42,6 @@ export default function Dashboard() {
         onSettingsClick={handleSettingsClick}
         onStatsClick={handleStatsClick}
         onDanceClick={handleDanceClick}
-        onMemoryClick={handleMemoryClick}
-        onBuzzClick={handleBuzzClick}
       />
     );
   } else if (currentComponent === "pomodoro") {
@@ -71,10 +57,6 @@ export default function Dashboard() {
         onWebSocketClose={handleDashClick}
       />
     );
-  } else if (currentComponent === "memory") {
-    RenderedComponent = <Memory />;
-  } else if (currentComponent === "buzz") {
-    RenderedComponent = <Buzzwire />;
   }
 
   let RenderedMenu;

--- a/src/styles/DashboardHome.css
+++ b/src/styles/DashboardHome.css
@@ -203,5 +203,8 @@
 
 .home-dashboard .game-tiles:hover {
   transform: scale(1.04);
+}
+
+.home-dashboard .dancing-game-tiles:hover {
   cursor: pointer;
 }


### PR DESCRIPTION
This pull request includes the following changes:

- Remove `onclick` events from memory and buzz wire components to streamline functionality.
- Remove related props and `handleClick` events from memory and buzz wire components.
- Remove `cursor: pointer` styling from memory and buzz wire tiles for better user interface consistency.